### PR TITLE
Upgraded to React 16.x and added PropTypes dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-thumbnail-zoom",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "beautiful transitions for viewing thumbnails",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/package.json
+++ b/package.json
@@ -21,15 +21,16 @@
   "dependencies": {
     "classnames": "^2.2.5",
     "react-portal": "^3.1.0",
-    "viewport-size": "^0.0.1"
+    "viewport-size": "^0.0.1",
+    "prop-types": "^15.6.0"
   },
   "peerDependencies": {
-    "react": "15.x"
+    "react": "16.x"
   },
   "devDependencies": {
     "nwb": "0.15.x",
-    "react": "^15.5.4",
-    "react-dom": "^15.5.4"
+    "react": "^16.2.0",
+    "react-dom": "^16.2.0"
   },
   "author": "",
   "homepage": "",

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ import React from "react";
 import classnames from "classnames";
 import viewport from "viewport-size";
 import Portal from "react-portal";
+import PropTypes from 'prop-types';
 
 class ImageZoom extends React.Component {
   constructor(props) {
@@ -14,14 +15,14 @@ class ImageZoom extends React.Component {
   }
 
   static propTypes = {
-    zoomedIn: React.PropTypes.bool,
-    onZoomToggle: React.PropTypes.func,
-    zoomedInURL: React.PropTypes.string,
-    padding: React.PropTypes.number,
-    duration: React.PropTypes.number,
-    loader: React.PropTypes.node,
-    overlay: React.PropTypes.bool,
-    closeButton: React.PropTypes.bool
+    zoomedIn: PropTypes.bool,
+    onZoomToggle: PropTypes.func,
+    zoomedInURL: PropTypes.string,
+    padding: PropTypes.number,
+    duration: PropTypes.number,
+    loader: PropTypes.node,
+    overlay: PropTypes.bool,
+    closeButton: PropTypes.bool
   };
 
   static defaultProps = {


### PR DESCRIPTION
Wanted to use your plugin in my app, but I'm using React 16.x and here PropTypes are refactored out of React. Thus this upgrade.